### PR TITLE
Limit epsilon comparisons to real signals

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -81,8 +81,13 @@ impl OwnedSignalValue {
     }
 
     /// Compare two values, using epsilon for real-valued signals when provided.
-    fn approx_eq(&self, other: &Self, real_epsilon: Option<f64>) -> bool {
-        match (self, other, real_epsilon) {
+    fn approx_eq(
+        &self,
+        other: &Self,
+        real_epsilon: Option<f64>,
+        use_real_epsilon: bool,
+    ) -> bool {
+        match (self, other, real_epsilon.filter(|_| use_real_epsilon)) {
             (OwnedSignalValue::Real(a), OwnedSignalValue::Real(b), Some(eps)) => {
                 (a - b).abs() <= eps
             }
@@ -106,6 +111,24 @@ impl OwnedSignalValue {
             _ => self == other,
         }
     }
+}
+
+fn is_real_var_type(var_type: &str) -> bool {
+    matches!(var_type, "real" | "realtime" | "shortreal" | "real_parameter")
+}
+
+fn handle_is_real(map: &SignalMap, handle: usize) -> bool {
+    map.get(&handle)
+        .is_some_and(|info| info.vars.iter().any(|v| is_real_var_type(v.meta.var_type)))
+}
+
+fn handles_are_real(
+    hier1: &WaveHierarchy,
+    handle1: usize,
+    hier2: &WaveHierarchy,
+    handle2: usize,
+) -> bool {
+    handle_is_real(&hier1.signal_map, handle1) && handle_is_real(&hier2.signal_map, handle2)
 }
 
 /// Compare signal names between two waveform files and return the differences
@@ -311,7 +334,9 @@ fn compare_signal_channels<W: Write>(
 
                     if let Some(value2) = found {
                         matched_at_current_time.insert(handle2);
-                        if !change1.value.approx_eq(&value2, real_epsilon) {
+                        let use_real_epsilon =
+                            handles_are_real(hier1, change1.handle, hier2, handle2);
+                        if !change1.value.approx_eq(&value2, real_epsilon, use_real_epsilon) {
                             has_differences = true;
                             for name in format_handle_names(change1.handle, &hier1.signal_map, &hier1.names) {
                                 writeln!(writer, "{} {} {} != {}", t1, name, change1.value, value2)?;

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -470,6 +470,21 @@ fn test_diff_epsilon_wide_bitvector_no_false_positive() {
     assert!(!has_diff, "Identical wide bit-vectors should not differ with epsilon. Output:\n{}", output);
 }
 
+#[test]
+fn test_diff_epsilon_does_not_mask_bitvector_difference() {
+    let (has_diff, output) = run_wave_diff_test_with_epsilon(
+        "tests/data/counter.vcd",
+        "tests/data/counter.value.diff.vcd",
+        Some(1000.0),
+    );
+    assert!(has_diff, "Bit-vector differences should stay exact with epsilon. Output:\n{}", output);
+
+    let expected = "\
+10 t.the_sub.cyc_plus_one 00000000000000000000000000000010 != 00000000000000000000000000000100
+";
+    assert_eq!(output, expected, "Expected exact diff output for VCD value diff");
+}
+
 // -- Metadata comparison tests ------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary

- apply `--epsilon` only when both matched handles are real-valued signals
- keep bit-vector and scalar logic comparisons exact even if their value strings parse as numbers
- add a regression using the existing `counter.value.diff.vcd` fixture with a large epsilon

## Why

`--epsilon` is documented as tolerance for real-valued signals. The current fallback in `OwnedSignalValue::approx_eq` parses any pair of display strings as `f64` when epsilon is set, so a vector mismatch like `...0010` vs `...0100` can be hidden by a large tolerance.

This keeps the existing FST/VCD real comparison path, but gates the numeric fallback on the normalized signal metadata.

## Validation

- `git diff --check`
- `cargo build --release`
- `cargo test --test diff_test epsilon`
- `cargo test`
- `cargo clippy -- -D warnings`
- `target/debug/wavediff --epsilon 1000 tests/data/counter.vcd tests/data/counter.value.diff.vcd` exits `1` and reports `t.the_sub.cyc_plus_one`

Fixes #8