### PR TITLE
Reject inverted wavecat time ranges

### DIFF
--- a/src/bin/wavecat.rs
+++ b/src/bin/wavecat.rs
@@ -119,6 +119,12 @@ fn main() {
 }
 
 fn process_wave_file(args: &Args) -> Result<(), String> {
+    if let (Some(s), Some(e)) = (args.start, args.end) {
+        if s > e {
+            return Err(format!("--start ({}) must be <= --end ({})", s, e));
+        }
+    }
+
     let name_options = NameOptions {
         no_range_space: args.no_range_space,
     };

--- a/tests/set_tests.rs
+++ b/tests/set_tests.rs
@@ -312,6 +312,22 @@ fn test_cli_wavecat_multi_file_attrs() {
 }
 
 #[test]
+fn test_cli_wavecat_start_after_end_fails() {
+    let output = run_wavecat_cli(&[
+        "--start", "40",
+        "--end", "10",
+        "tests/data/counter.vcd",
+    ]);
+    assert_eq!(output.status.code(), Some(1), "Expected exit 1");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("--start (40) must be <= --end (10)"),
+        "Expected invalid range error: {}",
+        stderr
+    );
+}
+
+#[test]
 fn test_cli_wavediff_set_no_diff() {
     // {set_clk + set_counter} vs {counter} = identical, exit 0
     let output = run_wavediff_cli(&[


### PR DESCRIPTION
Fixes #10.

## What changed

`wavecat` now rejects `--start` values that are greater than `--end` before opening the waveform.

## Why

Before this change, an inverted range exited successfully with empty output:

```text
wavecat --start 40 --end 10 tests/data/counter.vcd
```

That makes a typo look the same as a valid empty result. `wavediff` already rejects the same input shape, so this keeps the two CLIs consistent.

## Validation

Ran locally:

```text
git diff --check
cargo test --test set_tests test_cli_wavecat_start_after_end_fails
cargo test
cargo clippy -- -D warnings
target/debug/wavecat --start 40 --end 10 tests/data/counter.vcd
```

The direct CLI check exits 1 and prints:

```text
Error: --start (40) must be <= --end (10)
```
