### PR TITLE
Deduplicate aliased handle mappings in wavediff

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -161,7 +161,11 @@ fn build_handle_mapping(
             let segments = tree_a.segments(var.name);
             if let Some(b_name_id) = tree_b.find(&segments) {
                 if let Some(b_handles) = name_id_to_handles_b.get(&b_name_id) {
-                    handles_b.extend(b_handles);
+                    for &handle_b in b_handles {
+                        if !handles_b.contains(&handle_b) {
+                            handles_b.push(handle_b);
+                        }
+                    }
                 }
             }
         }

--- a/tests/data/error/idcode_a_value_diff.vcd
+++ b/tests/data/error/idcode_a_value_diff.vcd
@@ -1,0 +1,19 @@
+$timescale 1ps $end
+$scope module m $end
+$scope module s0 $end
+$var wire 1 ! a $end
+$var wire 1 " b $end
+$upscope $end
+$scope module s1 $end
+$var wire 1 # e $end
+$var wire 1 ! c $end
+$var wire 1 " d $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpvars
+0#
+1"
+1!
+$end

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -347,6 +347,20 @@ fn test_diff_vcd_aliased_idcodes_reverse_no_diff() {
     assert!(!has_diff, "Reversed aliased vs unique VCD id codes should not differ. Output:\n{}", output);
 }
 
+#[test]
+fn test_diff_vcd_aliased_idcodes_reports_each_name_once() {
+    let (has_diff, output) = run_wave_diff_test(
+        "tests/data/idcode_a.vcd",
+        "tests/data/error/idcode_a_value_diff.vcd",
+    );
+    assert!(has_diff, "Changed aliased id should differ");
+    let expected = "\
+0 m.s0.a 0 != 1
+0 m.s1.c 0 != 1
+";
+    assert_eq!(output, expected, "Expected one diff per aliased signal name");
+}
+
 // -- Time range filtering tests -----------------------------------------------
 
 fn run_wave_diff_test_with_range(


### PR DESCRIPTION
Fixes #12.

## What changed

`wavediff` now keeps each destination handle at most once when building the source-to-destination handle mapping.

## Why

When a VCD id code is shared by multiple signal names, each alias can resolve back to the same destination handle. The old mapping pushed that destination handle once per alias name, so a single differing aliased value could be reported multiple times.

With a changed aliased id based on the existing `idcode_a.vcd` fixture, the output before this change was:

```text
0 m.s0.a 0 != 1
0 m.s1.c 0 != 1
0 m.s0.a 0 != 1
0 m.s1.c 0 != 1
```

After this change it is reported once per aliased signal name:

```text
0 m.s0.a 0 != 1
0 m.s1.c 0 != 1
```

## Validation

Ran locally:

```text
git diff --check
cargo test --test diff_test test_diff_vcd_aliased_idcodes_reports_each_name_once
cargo test
cargo clippy -- -D warnings
target/debug/wavediff tests/data/idcode_a.vcd tests/data/error/idcode_a_value_diff.vcd
```

The direct `wavediff` check exits 1 and prints the two expected diff lines shown above.
