### PR TITLE
Classify wavediff name mismatches as differences

### DIFF
--- a/src/bin/wavediff.rs
+++ b/src/bin/wavediff.rs
@@ -94,9 +94,9 @@ fn report_name_mismatch(
     only_in_1: &std::collections::HashSet<String>,
     file2: &std::path::Path,
     only_in_2: &std::collections::HashSet<String>,
-) -> Result<(), String> {
+) -> bool {
     if only_in_1.is_empty() && only_in_2.is_empty() {
-        return Ok(());
+        return false;
     }
     eprintln!("Signal name mismatch:");
     let print_sorted = |label: std::path::Display, names: &std::collections::HashSet<String>| {
@@ -113,7 +113,7 @@ fn report_name_mismatch(
     if !only_in_2.is_empty() {
         print_sorted(file2.display(), only_in_2);
     }
-    Err("Signal names differ between files".to_string())
+    true
 }
 
 fn report_meta_diffs(
@@ -181,11 +181,10 @@ fn run(args: Args) -> Result<bool, String> {
     let label2 = args.file2.as_deref().unwrap_or(set2_paths[0].as_path());
 
     let (only_in_1, only_in_2) = compare_signal_names(&sets.hier1, &sets.hier2);
-    report_name_mismatch(label1, &only_in_1, label2, &only_in_2)?;
+    let mut has_differences = report_name_mismatch(label1, &only_in_1, label2, &only_in_2);
 
-    let mut has_differences = false;
     if !args.no_attrs {
-        has_differences = report_meta_diffs(&sets.hier1, &sets.hier2);
+        has_differences |= report_meta_diffs(&sets.hier1, &sets.hier2);
     }
 
     let diff_options = DiffOptions {

--- a/tests/set_tests.rs
+++ b/tests/set_tests.rs
@@ -336,6 +336,20 @@ fn test_cli_wavediff_set_value_diff() {
 }
 
 #[test]
+fn test_cli_wavediff_name_mismatch_exits_difference() {
+    let output = run_wavediff_cli(&[
+        "tests/data/counter.fst",
+        "tests/data/counter.new_sig.diff.fst",
+    ]);
+
+    assert_eq!(output.status.code(), Some(1), "Expected exit 1");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("Signal name mismatch"), "Expected name mismatch: {}", stderr);
+    assert!(stderr.contains("t.the_sub.new_sig"), "Expected missing signal: {}", stderr);
+    assert!(!stderr.contains("Error:"), "Name mismatches should not use the error path: {}", stderr);
+}
+
+#[test]
 fn test_cli_wavediff_set_conflict() {
     // set_clk + set_overlap in set1 = duplicate signal, exit 2
     let output = run_wavediff_cli(&[


### PR DESCRIPTION
Fixes #14.

`wavediff` documents exit code 1 for differences and 2 for errors. Signal-name mismatches are a valid comparison result, but the CLI currently reports them through the error path, prints an `Error:` line, and exits 2.

This keeps the existing name-mismatch report, treats it as a difference, and lets the normal `has_differences` return path produce exit 1. The regression uses an existing FST/FST pair with one extra signal and verifies the mismatch stays out of the error path.

Validation:
- `git diff --check`
- `cargo test --test set_tests test_cli_wavediff_name_mismatch_exits_difference`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo run --quiet --bin wavediff -- tests/data/counter.fst tests/data/counter.new_sig.diff.fst` exits 1 and reports only `t.the_sub.new_sig` as the name mismatch