### PR TITLE
Trim trailing wavediff samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,14 @@ $ wavediff golden.fst test.fst
 10 t.the_sub.cyc_plus_one 00000000000000000000000000000010 != 00000000000000000000000000000100
 ```
 
-The second file ends earlier, so time 50 is missing:
+If one file has only trailing samples beyond the other, the text report prints
+all diffs up to the shorter input and ignores later samples from the longer
+input. The notice is reported on stderr after stdout diff rows have been
+emitted:
 
 ```
 $ wavediff golden.fst short.fst
-50 t.clk 1 (missing time in file2)
+Ignored trailing samples in golden.fst after time 40 to match the shorter input
 ```
 
 A clock edge moved from time 20 to time 21:

--- a/src/bin/wavediff.rs
+++ b/src/bin/wavediff.rs
@@ -10,8 +10,9 @@ use clap::Parser;
 use std::io::Write;
 use std::path::PathBuf;
 use wavetools::{
-    apply_filter, compare_signal_meta, compare_signal_names, diff_wave_sets,
-    open_and_read_wave_sets, parse_filter_patterns, DiffOptions, NameOptions, WaveHierarchy,
+    apply_filter, compare_signal_meta, compare_signal_names, diff_wave_sets_with_report,
+    open_and_read_wave_sets, parse_filter_patterns, DiffOptions, DiffOutputOptions, DiffSide,
+    NameOptions, WaveHierarchy,
 };
 
 const VERSION: &str = concat!(
@@ -201,8 +202,24 @@ fn run(args: Args) -> Result<bool, String> {
         real_epsilon: args.epsilon,
     };
     let mut stdout = std::io::stdout();
-    let value_diffs = diff_wave_sets(&mut stdout, sets, &diff_options)
-        .map_err(|e| format!("Failed to diff files: {}", e))?;
+    let diff_report = diff_wave_sets_with_report(
+        &mut stdout,
+        sets,
+        &diff_options,
+        &DiffOutputOptions::default(),
+    )
+    .map_err(|e| format!("Failed to diff files: {}", e))?;
 
-    Ok(has_differences || value_diffs)
+    if let Some(trim) = &diff_report.trim {
+        let label = match trim.side {
+            DiffSide::First => label1.display(),
+            DiffSide::Second => label2.display(),
+        };
+        eprintln!(
+            "Ignored trailing samples in {} after time {} to match the shorter input",
+            label, trim.trim_time
+        );
+    }
+
+    Ok(has_differences || diff_report.has_differences)
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -23,6 +23,31 @@ pub struct DiffOptions {
     pub real_epsilon: Option<f64>,
 }
 
+/// Additional output and comparison controls used by the CLI.
+#[derive(Default)]
+pub struct DiffOutputOptions {}
+
+/// Which input had trailing samples ignored because it extended beyond the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffSide {
+    First,
+    Second,
+}
+
+/// Report for ignored trailing samples beyond the shorter input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrimReport {
+    pub side: DiffSide,
+    pub trim_time: u64,
+}
+
+/// Full result of a diff run.
+#[derive(Debug, Default)]
+pub struct DiffReport {
+    pub has_differences: bool,
+    pub trim: Option<TrimReport>,
+}
+
 /// Result of opening two wave file sets for comparison.
 pub struct WaveSets {
     pub readers1: Vec<WaveReader>,
@@ -327,9 +352,13 @@ fn emit_file2_only<W: Write>(
     writeln!(writer, "{} {} {} (only in file2)", time, name, value)
 }
 
+/// Record the first trailing-sample trim seen on a side (keeps the earliest).
+fn note_trim(trim: &mut Option<TrimReport>, side: DiffSide, trim_time: u64) {
+    trim.get_or_insert(TrimReport { side, trim_time });
+}
+
 /// Consumes batches from `rx1` (file1) and `rx2` (file2), buffering as needed to
-/// match signals across potentially different orderings. Returns `true` if differences
-/// were found.
+/// match signals across potentially different orderings.
 fn compare_signal_channels<W: Write>(
     writer: &mut W,
     rx1: channel::Receiver<TimeBatch>,
@@ -338,8 +367,9 @@ fn compare_signal_channels<W: Write>(
     hier1: &WaveHierarchy,
     hier2: &WaveHierarchy,
     real_epsilon: Option<f64>,
-) -> std::io::Result<bool> {
+) -> std::io::Result<DiffReport> {
     let mut has_differences = false;
+    let mut trim = None;
     // File2 changes we've read from the channel but haven't matched yet,
     // keyed by (time, handle) so we can look them up when file1 catches up.
     let mut buffered2: HashMap<(u64, usize), OwnedSignalValue> = HashMap::new();
@@ -348,21 +378,30 @@ fn compare_signal_channels<W: Write>(
     let mut matched_at_current_time: HashSet<usize> = HashSet::new();
     let mut prev_time: Option<u64> = None;
     let mut source2_ended = false;
+    let mut last_time2: Option<u64> = None;
 
-    // Drive the comparison from file1's batch stream.
+    // Drive the comparison from file1's batch stream.  Even after file2
+    // ends, keep draining file1 instead of breaking: rx1 is bounded, so
+    // bailing out here could leave the file1 reader thread blocked on send
+    // before we join it.
     for batch1 in &rx1 {
+        let t1 = batch1.time;
+        if source2_ended && last_time2.is_none_or(|t2| t1 >= t2) {
+            note_trim(&mut trim, DiffSide::First, last_time2.unwrap_or(0));
+            continue;
+        }
+
         // When we move to a new time step, evict buffer entries for file2
         // handles that were already matched -- they won't be needed again.
         if let Some(pt) = prev_time {
-            if pt != batch1.time {
+            if pt != t1 {
                 for &handle in &matched_at_current_time {
                     buffered2.remove(&(pt, handle));
                 }
                 matched_at_current_time.clear();
             }
         }
-        prev_time = Some(batch1.time);
-        let t1 = batch1.time;
+        prev_time = Some(t1);
 
         for change1 in batch1.changes {
             if let Some(handles2) = handle_mapping.get(&change1.handle) {
@@ -378,6 +417,7 @@ fn compare_signal_channels<W: Write>(
                             match rx2.recv() {
                                 Ok(batch2) => {
                                     let t2 = batch2.time;
+                                    last_time2 = Some(t2);
                                     if t2 == t1 {
                                         saw_time_in_source2 = true;
                                     }
@@ -420,6 +460,10 @@ fn compare_signal_channels<W: Write>(
                             )?;
                         }
                     } else {
+                        if source2_ended && last_time2.is_none_or(|t2| t1 >= t2) {
+                            note_trim(&mut trim, DiffSide::First, last_time2.unwrap_or(0));
+                            continue;
+                        }
                         has_differences = true;
                         let msg = if saw_time_in_source2 {
                             "(not in file2)"
@@ -453,11 +497,18 @@ fn compare_signal_channels<W: Write>(
         .drain()
         .filter(|((_t, h), _)| hier2.signal_map.contains_key(h))
         .collect();
-    if !owned.is_empty() {
+    if owned
+        .iter()
+        .any(|((time, _), _)| prev_time.is_some_and(|t1| *time < t1))
+    {
         has_differences = true;
     }
     let mut file2_only_rows: Vec<(u64, String, usize)> = Vec::new();
     for (idx, ((time, handle), _)) in owned.iter().enumerate() {
+        if prev_time.is_none_or(|t1| *time >= t1) {
+            note_trim(&mut trim, DiffSide::Second, prev_time.unwrap_or(0));
+            continue;
+        }
         for name in format_handle_names(*handle, &hier2.signal_map, &hier2.names) {
             file2_only_rows.push((*time, name, idx));
         }
@@ -476,6 +527,10 @@ fn compare_signal_channels<W: Write>(
                 if !hier2.signal_map.contains_key(&change2.handle) {
                     continue;
                 }
+                if prev_time.is_none_or(|t1| batch2.time >= t1) {
+                    note_trim(&mut trim, DiffSide::Second, prev_time.unwrap_or(0));
+                    continue;
+                }
                 has_differences = true;
                 for name in format_handle_names(change2.handle, &hier2.signal_map, &hier2.names) {
                     emit_file2_only(writer, &name, batch2.time, &change2.value)?;
@@ -484,7 +539,10 @@ fn compare_signal_channels<W: Write>(
         }
     }
 
-    Ok(has_differences)
+    Ok(DiffReport {
+        has_differences,
+        trim,
+    })
 }
 
 /// Send all signal changes from a WaveReader through a channel, applying time filtering.
@@ -740,6 +798,19 @@ pub fn diff_wave_sets<W: Write>(
     sets: WaveSets,
     options: &DiffOptions,
 ) -> std::io::Result<bool> {
+    Ok(
+        diff_wave_sets_with_report(writer, sets, options, &DiffOutputOptions::default())?
+            .has_differences,
+    )
+}
+
+/// Compare two sets of waveform files and return a full diff report.
+pub fn diff_wave_sets_with_report<W: Write>(
+    writer: &mut W,
+    sets: WaveSets,
+    options: &DiffOptions,
+    _output_options: &DiffOutputOptions,
+) -> std::io::Result<DiffReport> {
     let handle_mapping = build_handle_mapping(
         &sets.hier1.signal_map,
         &sets.hier1.names,
@@ -791,11 +862,11 @@ pub fn diff_wave_sets<W: Write>(
         Err(_) => Err(io::Error::other("wavediff set2 reader thread panicked")),
     };
 
-    let has_differences = result?;
+    let report = result?;
     thread1_result?;
     thread2_result?;
 
-    Ok(has_differences)
+    Ok(report)
 }
 
 /// Open two sets of waveform files and return readers and merged hierarchies

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,9 @@ mod vcd;
 
 pub use cat::{write_signals_wave, write_signals_wave_multi, SignalOutputOptions};
 pub use diff::{
-    compare_signal_meta, compare_signal_names, diff_wave_sets, diff_waves, open_and_read_wave_sets,
-    open_and_read_waves, DiffOptions, WaveSets,
+    compare_signal_meta, compare_signal_names, diff_wave_sets, diff_wave_sets_with_report,
+    diff_waves, open_and_read_wave_sets, open_and_read_waves, DiffOptions, DiffOutputOptions,
+    DiffReport, DiffSide, TrimReport, WaveSets,
 };
 
 use fst_reader::{

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -46,14 +46,14 @@ fn test_diff_end_time() {
         "tests/data/counter.end_time.diff.fst",
     );
     assert!(
-        has_diff,
-        "counter.end_time.diff.fst should differ from counter.fst"
+        !has_diff,
+        "Trailing samples beyond the shorter file should be ignored. Output:\n{}",
+        output
     );
-
-    let expected = "\
-50 t.clk 1 (missing time in file2)
-";
-    assert_eq!(output, expected, "Expected exact diff output");
+    assert_eq!(
+        output, "",
+        "Ignored trailing samples should not produce diff output"
+    );
 }
 
 // Tests for files that should NOT differ from counter.fst
@@ -190,6 +190,118 @@ fn test_buffered_file2_only_diffs_are_sorted() {
 }
 
 #[test]
+fn test_terminal_same_tick_file1_only_changes_are_trimmed() {
+    let pid = std::process::id();
+    let file1 = std::env::temp_dir().join(format!("wavetools-terminal-trim-{}-1.vcd", pid));
+    let file2 = std::env::temp_dir().join(format!("wavetools-terminal-trim-{}-2.vcd", pid));
+    std::fs::write(
+        &file1,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 1 \" a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1!
+1\"
+",
+    )
+    .expect("write file1");
+    std::fs::write(
+        &file2,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 1 \" a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1!
+",
+    )
+    .expect("write file2");
+
+    let (has_diff, output) = run_wave_diff_test(
+        file1.to_str().expect("temp path should be UTF-8"),
+        file2.to_str().expect("temp path should be UTF-8"),
+    );
+    assert!(
+        !has_diff,
+        "terminal file1-only changes should be trim-only. Output:\n{}",
+        output
+    );
+    assert_eq!(output, "");
+
+    let _ = std::fs::remove_file(file1);
+    let _ = std::fs::remove_file(file2);
+}
+
+#[test]
+fn test_terminal_same_tick_file2_only_changes_are_trimmed() {
+    let pid = std::process::id();
+    let file1 = std::env::temp_dir().join(format!("wavetools-terminal-trim-{}-a.vcd", pid));
+    let file2 = std::env::temp_dir().join(format!("wavetools-terminal-trim-{}-b.vcd", pid));
+    std::fs::write(
+        &file1,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 1 \" a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1!
+",
+    )
+    .expect("write file1");
+    std::fs::write(
+        &file2,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 1 \" a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1!
+1\"
+",
+    )
+    .expect("write file2");
+
+    let (has_diff, output) = run_wave_diff_test(
+        file1.to_str().expect("temp path should be UTF-8"),
+        file2.to_str().expect("temp path should be UTF-8"),
+    );
+    assert!(
+        !has_diff,
+        "terminal file2-only changes should be trim-only. Output:\n{}",
+        output
+    );
+    assert_eq!(output, "");
+
+    let _ = std::fs::remove_file(file1);
+    let _ = std::fs::remove_file(file2);
+}
+
+#[test]
 fn test_new_sig_diff() {
     let (has_name_diff, msg) = check_signal_names(
         "tests/data/counter.fst",
@@ -314,15 +426,13 @@ fn test_diff_vcd_end_time() {
         "tests/data/counter.end_time.diff.vcd",
     );
     assert!(
-        has_diff,
-        "counter.end_time.diff.vcd should differ from counter.vcd"
+        !has_diff,
+        "Trailing samples beyond the shorter file should be ignored. Output:\n{}",
+        output
     );
-    let expected = "\
-50 t.clk 1 (missing time in file2)
-";
     assert_eq!(
-        output, expected,
-        "Expected exact diff output for VCD end time diff"
+        output, "",
+        "Ignored trailing samples should not produce diff output"
     );
 }
 
@@ -1347,6 +1457,27 @@ fn test_cli_filter_invalid_glob_exits_with_error() {
     assert!(
         stderr.contains("Invalid glob pattern"),
         "stderr should mention the invalid pattern: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_cli_wavediff_reports_ignored_longer_input() {
+    let output = run_wavediff_cli(&[
+        "tests/data/counter.fst",
+        "tests/data/counter.end_time.diff.fst",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "Trailing-only comparison should exit 0. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Ignored trailing samples in tests/data/counter.fst after time 40"),
+        "stderr should report ignored trailing samples: {}",
         stderr
     );
 }


### PR DESCRIPTION
Stacked PRs:
 * #29
 * #28
 * #27
 * __->__#26


--- --- ---

### Trim trailing wavediff samples


Diffs of differing time lengths will not compare last tick noise or diffs beyond the shorter of the two.
It will print the trimming time and finish
