### PR TITLE
Add wavediff --fst-diff output

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ they are included in their respective sets.
 | `-f, --filter <PATTERN>` | Filter signals by glob pattern; may be repeated or space-separated |
 | `--ignore-missing` | Ignore signals that are missing from either input |
 | `--ignore-xz` | Ignore value differences only for bits where either side is X or Z |
+| `--fst-diff <FILE>` | Write an FST containing side-by-side values for signals that had value differences |
 
 ### Exit codes
 
@@ -220,6 +221,21 @@ known bit differs:
 
 ```
 wavediff --ignore-xz golden.fst test.fst
+```
+
+`--ignore-xz` assumes X-like unknown bits come from only one side (e.g. an
+uninitialized golden model). If both sides hold X-like bits, masking would hide
+real discrepancies, so wavediff prints the full diff and then errors:
+
+```
+$ wavediff --ignore-xz golden.fst test.fst
+wavediff --ignore-xz: both sides hold X-like bits; drop --ignore-xz to compare them
+```
+
+Write an FST with side-by-side values for signals that differed:
+
+```
+wavediff --fst-diff diff.fst golden.fst test.fst
 ```
 
 Combine multiple files per side and diff the merged sets:

--- a/src/bin/wavediff.rs
+++ b/src/bin/wavediff.rs
@@ -8,11 +8,11 @@
 
 use clap::Parser;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use wavetools::{
     apply_filter, compare_signal_meta, compare_signal_names, diff_wave_sets_with_report,
     open_and_read_wave_sets, parse_filter_patterns, retain_common_signals, DiffOptions,
-    DiffOutputOptions, DiffSide, NameOptions, WaveHierarchy,
+    DiffOutputOptions, DiffSide, FstDiffOutput, FstDiffSide, NameOptions, SidePair, WaveHierarchy,
 };
 
 const VERSION: &str = concat!(
@@ -43,6 +43,7 @@ Examples:
   wavediff --epsilon 0.001 analog1.fst analog2.vcd
   wavediff --ignore-xz sim1.fst sim2.fst
   wavediff --ignore-missing sim1.fst sim2.fst
+  wavediff --fst-diff diff.fst baseline.fst current.fst
   wavediff --set1 extra1.vcd baseline.vcd current.vcd
   wavediff --set1 clk.vcd --set1 regs.vcd --set2 counter.vcd
   wavediff --set1 clk.vcd --set1 regs.vcd --set2 clk.vcd --set2 regs_new.vcd baseline.vcd current.vcd"
@@ -90,6 +91,10 @@ struct Args {
     /// Ignore value differences only for bits where either side is X or Z
     #[arg(long = "ignore-xz")]
     ignore_xz: bool,
+
+    /// Write an FST containing only signals that had value differences
+    #[arg(long = "fst-diff")]
+    fst_diff: Option<PathBuf>,
 }
 
 fn main() {
@@ -146,6 +151,15 @@ fn report_meta_diffs(hier1: &WaveHierarchy, hier2: &WaveHierarchy) -> bool {
     } else {
         false
     }
+}
+
+fn side_label(path: &Path, fallback: &str) -> String {
+    path.file_stem()
+        .or_else(|| path.file_name())
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(fallback)
+        .to_string()
 }
 
 fn run(args: Args) -> Result<bool, String> {
@@ -216,6 +230,28 @@ fn run(args: Args) -> Result<bool, String> {
         end: args.end,
         real_epsilon: args.epsilon,
     };
+    let fst_diff = args.fst_diff.as_ref().map(|path| {
+        let mut side1 = side_label(label1, "file1");
+        let mut side2 = side_label(label2, "file2");
+        if side1 == side2 {
+            side1.push_str("_file1");
+            side2.push_str("_file2");
+        }
+        FstDiffOutput {
+            path: path.clone(),
+            sides: SidePair {
+                side1: FstDiffSide {
+                    label: side1,
+                    paths: set1_paths.clone(),
+                },
+                side2: FstDiffSide {
+                    label: side2,
+                    paths: set2_paths.clone(),
+                },
+            },
+            name_options: name_options.clone(),
+        }
+    });
     let mut stdout = std::io::stdout();
     let diff_report = diff_wave_sets_with_report(
         &mut stdout,
@@ -223,6 +259,7 @@ fn run(args: Args) -> Result<bool, String> {
         &diff_options,
         &DiffOutputOptions {
             ignore_xz: args.ignore_xz,
+            fst_diff,
         },
     )
     .map_err(|e| format!("Failed to diff files: {}", e))?;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -14,6 +14,8 @@ use std::path::Path;
 use crossbeam_channel as channel;
 use fst_reader::{FstFilter, FstSignalHandle, FstSignalValue};
 
+use crate::diff_report::DiffReportRows;
+use crate::fst_diff::{FstDiffOutput, FstDiffRecorder};
 use crate::{next_vcd_change, NameOptions, NameTree, SignalMap, WaveHierarchy, WaveReader};
 
 /// Options controlling diff behavior (time range, epsilon).
@@ -27,6 +29,7 @@ pub struct DiffOptions {
 #[derive(Default)]
 pub struct DiffOutputOptions {
     pub ignore_xz: bool,
+    pub fst_diff: Option<FstDiffOutput>,
 }
 
 /// Which input had trailing samples ignored because it extended beyond the other.
@@ -48,6 +51,7 @@ pub struct TrimReport {
 pub struct DiffReport {
     pub has_differences: bool,
     pub trim: Option<TrimReport>,
+    pub fst_diff_signal_count: usize,
 }
 
 /// Result of opening two wave file sets for comparison.
@@ -70,7 +74,7 @@ const BATCH_SIZE: usize = 4096;
 
 /// Owned version of `FstSignalValue` for sending through channels
 #[derive(Debug, Clone)]
-enum OwnedSignalValue {
+pub(crate) enum OwnedSignalValue {
     String(Vec<u8>),
     Real(f64),
 }
@@ -165,6 +169,14 @@ impl OwnedSignalValue {
             }
         })
     }
+
+    /// True if the value holds any X-like bit (`x`, `u`, `w`, `-`, `?`, ...).
+    fn has_x_like_bits(&self) -> bool {
+        match self {
+            OwnedSignalValue::String(bytes) => bytes.iter().any(|byte| is_x_like_bit(*byte)),
+            OwnedSignalValue::Real(_) => false,
+        }
+    }
 }
 
 fn is_xz_mask_bit(byte: u8) -> bool {
@@ -172,6 +184,10 @@ fn is_xz_mask_bit(byte: u8) -> bool {
         byte,
         b'x' | b'X' | b'z' | b'Z' | b'u' | b'U' | b'w' | b'W' | b'-' | b'?'
     )
+}
+
+fn is_x_like_bit(byte: u8) -> bool {
+    matches!(byte, b'x' | b'X' | b'u' | b'U' | b'w' | b'W' | b'-' | b'?')
 }
 
 fn is_logic_value_byte(byte: u8) -> bool {
@@ -249,6 +265,13 @@ fn build_name_id_to_handles(map: &SignalMap) -> HashMap<crate::NameId, Vec<usize
     result
 }
 
+#[derive(Debug)]
+struct HandleMatch {
+    name_a: crate::NameId,
+    name_b: crate::NameId,
+    handle_b: usize,
+}
+
 /// Build mapping from handles in file A to handles in file B using tree-based lookup.
 ///
 /// For each signal in A, walks A's tree to get segments, then looks up those
@@ -259,26 +282,32 @@ fn build_handle_mapping(
     tree_a: &NameTree,
     map_b: &SignalMap,
     tree_b: &NameTree,
-) -> HashMap<usize, Vec<usize>> {
+) -> HashMap<usize, Vec<HandleMatch>> {
     let name_id_to_handles_b = build_name_id_to_handles(map_b);
-    let mut handle_mapping: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut handle_mapping: HashMap<usize, Vec<HandleMatch>> = HashMap::new();
 
     for (&handle_a, info) in map_a {
-        let mut handles_b = Vec::new();
+        let mut matches = Vec::new();
         for var in &info.vars {
             let segments = tree_a.segments(var.name);
             if let Some(b_name_id) = tree_b.find(&segments) {
                 if let Some(b_handles) = name_id_to_handles_b.get(&b_name_id) {
                     for &handle_b in b_handles {
-                        if !handles_b.contains(&handle_b) {
-                            handles_b.push(handle_b);
+                        if !matches.iter().any(|m: &HandleMatch| {
+                            m.name_a == var.name && m.name_b == b_name_id && m.handle_b == handle_b
+                        }) {
+                            matches.push(HandleMatch {
+                                name_a: var.name,
+                                name_b: b_name_id,
+                                handle_b,
+                            });
                         }
                     }
                 }
             }
         }
-        if !handles_b.is_empty() {
-            handle_mapping.insert(handle_a, handles_b);
+        if !matches.is_empty() {
+            handle_mapping.insert(handle_a, matches);
         }
     }
 
@@ -287,17 +316,17 @@ fn build_handle_mapping(
 
 /// A single signal value change (handle + value; time is on the enclosing TimeBatch).
 #[derive(Debug)]
-struct SignalChange {
-    handle: usize,
-    value: OwnedSignalValue,
+pub(crate) struct SignalChange {
+    pub(crate) handle: usize,
+    pub(crate) value: OwnedSignalValue,
 }
 
 /// A batch of signal changes all at the same simulation time.
 /// Batches are capped at BATCH_SIZE; a single time step may span multiple batches.
 #[derive(Debug)]
-struct TimeBatch {
-    time: u64,
-    changes: Vec<SignalChange>,
+pub(crate) struct TimeBatch {
+    pub(crate) time: u64,
+    pub(crate) changes: Vec<SignalChange>,
 }
 
 /// Flush the current batch through `tx`, replacing it with a fresh empty vec.
@@ -380,43 +409,8 @@ fn read_and_send_signals<R: BufRead + Seek>(
     Ok(())
 }
 
-/// Format signal names for a handle on-demand from SignalMap + NameTree.
-/// Only called on diff output lines, so the cost is proportional to mismatches.
-fn format_handle_names(handle: usize, map: &SignalMap, tree: &NameTree) -> Vec<String> {
-    match map.get(&handle) {
-        Some(info) => info.vars.iter().map(|v| tree.format_path(v.name)).collect(),
-        None => Vec::new(),
-    }
-}
-
-/// Write a `value1 != value2` row for every name `handle1` resolves to in file1.
-fn emit_value_diff<W: Write>(
-    writer: &mut W,
-    handle1: usize,
-    hier1: &WaveHierarchy,
-    time: u64,
-    value1: &OwnedSignalValue,
-    value2: &OwnedSignalValue,
-) -> std::io::Result<()> {
-    for name in format_handle_names(handle1, &hier1.signal_map, &hier1.names) {
-        writeln!(writer, "{} {} {} != {}", time, name, value1, value2)?;
-    }
-    Ok(())
-}
-
-/// Write a single `value (only in file2)` row for an already-resolved name.
-fn emit_file2_only<W: Write>(
-    writer: &mut W,
-    name: &str,
-    time: u64,
-    value: &OwnedSignalValue,
-) -> std::io::Result<()> {
-    writeln!(writer, "{} {} {} (only in file2)", time, name, value)
-}
-
-/// Record the first trailing-sample trim seen on a side (keeps the earliest).
-fn note_trim(trim: &mut Option<TrimReport>, side: DiffSide, trim_time: u64) {
-    trim.get_or_insert(TrimReport { side, trim_time });
+fn format_name(name: crate::NameId, tree: &NameTree) -> String {
+    tree.format_path(name)
 }
 
 struct CompareSignalContext<'a> {
@@ -426,21 +420,70 @@ struct CompareSignalContext<'a> {
     ignore_xz: bool,
 }
 
+/// Push a `value1 != value2` row for `name_a` and record it for fst-diff.
+fn emit_value_diff(
+    rows: &mut DiffReportRows,
+    fst_diff: &mut Option<&mut FstDiffRecorder>,
+    hier1: &WaveHierarchy,
+    name_a: crate::NameId,
+    time: u64,
+    value1: &OwnedSignalValue,
+    value2: &OwnedSignalValue,
+) {
+    let name = format_name(name_a, &hier1.names);
+    rows.push(
+        time,
+        name.clone(),
+        format!("{} {} {} != {}", time, name, value1, value2),
+    );
+    if let Some(recorder) = fst_diff.as_deref_mut() {
+        let segments = hier1.names.segments(name_a);
+        recorder.record_diff(&segments);
+    }
+}
+
+/// Push `value (only in file2)` rows for every name `handle2` resolves to and
+/// record them for fst-diff.
+fn emit_file2_only(
+    rows: &mut DiffReportRows,
+    fst_diff: &mut Option<&mut FstDiffRecorder>,
+    hier2: &WaveHierarchy,
+    handle2: usize,
+    time: u64,
+    value: &OwnedSignalValue,
+) {
+    let Some(info) = hier2.signal_map.get(&handle2) else {
+        return;
+    };
+    for var in &info.vars {
+        let name = hier2.names.format_path(var.name);
+        rows.push(
+            time,
+            name.clone(),
+            format!("{} {} {} (only in file2)", time, name, value),
+        );
+        if let Some(recorder) = fst_diff.as_deref_mut() {
+            let segments = hier2.names.segments(var.name);
+            recorder.record_side2_only(&segments);
+        }
+    }
+}
+
+/// Record the first trailing-sample trim seen on a side (keeps the earliest).
+fn note_trim(trim: &mut Option<TrimReport>, side: DiffSide, trim_time: u64) {
+    trim.get_or_insert(TrimReport { side, trim_time });
+}
+
 /// Consumes batches from `rx1` (file1) and `rx2` (file2), buffering as needed to
 /// match signals across potentially different orderings.
 fn compare_signal_channels<W: Write>(
     writer: &mut W,
     rx1: channel::Receiver<TimeBatch>,
     rx2: channel::Receiver<TimeBatch>,
-    handle_mapping: &HashMap<usize, Vec<usize>>,
+    handle_mapping: &HashMap<usize, Vec<HandleMatch>>,
     context: CompareSignalContext<'_>,
+    mut fst_diff: Option<&mut FstDiffRecorder>,
 ) -> std::io::Result<DiffReport> {
-    let CompareSignalContext {
-        hier1,
-        hier2,
-        real_epsilon,
-        ignore_xz,
-    } = context;
     let mut has_differences = false;
     let mut trim = None;
     // File2 changes we've read from the channel but haven't matched yet,
@@ -452,6 +495,7 @@ fn compare_signal_channels<W: Write>(
     let mut prev_time: Option<u64> = None;
     let mut source2_ended = false;
     let mut last_time2: Option<u64> = None;
+    let mut diff_rows = DiffReportRows::default();
 
     // Drive the comparison from file1's batch stream.  Even after file2
     // ends, keep draining file1 instead of breaking: rx1 is bounded, so
@@ -477,8 +521,9 @@ fn compare_signal_channels<W: Write>(
         prev_time = Some(t1);
 
         for change1 in batch1.changes {
-            if let Some(handles2) = handle_mapping.get(&change1.handle) {
-                for &handle2 in handles2 {
+            if let Some(matches) = handle_mapping.get(&change1.handle) {
+                for matched in matches {
+                    let handle2 = matched.handle_b;
                     let mut found = buffered2.get(&(t1, handle2)).cloned();
                     let mut saw_time_in_source2 = false;
 
@@ -517,22 +562,23 @@ fn compare_signal_channels<W: Write>(
                     if let Some(value2) = found {
                         matched_at_current_time.insert(handle2);
                         let use_real_epsilon =
-                            handles_are_real(hier1, change1.handle, hier2, handle2);
+                            handles_are_real(context.hier1, change1.handle, context.hier2, handle2);
                         if !change1.value.approx_eq(
                             &value2,
-                            real_epsilon,
+                            context.real_epsilon,
                             use_real_epsilon,
-                            ignore_xz,
+                            context.ignore_xz,
                         ) {
                             has_differences = true;
                             emit_value_diff(
-                                writer,
-                                change1.handle,
-                                hier1,
+                                &mut diff_rows,
+                                &mut fst_diff,
+                                context.hier1,
+                                matched.name_a,
                                 t1,
                                 &change1.value,
                                 &value2,
-                            )?;
+                            );
                         }
                     } else {
                         if source2_ended && last_time2.is_none_or(|t2| t1 >= t2) {
@@ -545,10 +591,15 @@ fn compare_signal_channels<W: Write>(
                         } else {
                             "(missing time in file2)"
                         };
-                        for name in
-                            format_handle_names(change1.handle, &hier1.signal_map, &hier1.names)
-                        {
-                            writeln!(writer, "{} {} {} {}", t1, name, change1.value, msg)?;
+                        let name = format_name(matched.name_a, &context.hier1.names);
+                        diff_rows.push(
+                            t1,
+                            name.clone(),
+                            format!("{} {} {} {}", t1, name, change1.value, msg),
+                        );
+                        if let Some(recorder) = fst_diff.as_deref_mut() {
+                            let segments = context.hier1.names.segments(matched.name_a);
+                            recorder.record_diff(&segments);
                         }
                     }
                 }
@@ -570,7 +621,7 @@ fn compare_signal_channels<W: Write>(
     // iteration order.
     let owned: Vec<((u64, usize), OwnedSignalValue)> = buffered2
         .drain()
-        .filter(|((_t, h), _)| hier2.signal_map.contains_key(h))
+        .filter(|((_t, h), _)| context.hier2.signal_map.contains_key(h))
         .collect();
     if owned
         .iter()
@@ -578,19 +629,19 @@ fn compare_signal_channels<W: Write>(
     {
         has_differences = true;
     }
-    let mut file2_only_rows: Vec<(u64, String, usize)> = Vec::new();
-    for (idx, ((time, handle), _)) in owned.iter().enumerate() {
+    for ((time, handle), value) in &owned {
         if prev_time.is_none_or(|t1| *time >= t1) {
             note_trim(&mut trim, DiffSide::Second, prev_time.unwrap_or(0));
             continue;
         }
-        for name in format_handle_names(*handle, &hier2.signal_map, &hier2.names) {
-            file2_only_rows.push((*time, name, idx));
-        }
-    }
-    file2_only_rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-    for (time, name, idx) in file2_only_rows {
-        emit_file2_only(writer, &name, time, &owned[idx].1)?;
+        emit_file2_only(
+            &mut diff_rows,
+            &mut fst_diff,
+            context.hier2,
+            *handle,
+            *time,
+            value,
+        );
     }
 
     // Drain any remaining file2 batches we never read from the channel.
@@ -599,7 +650,7 @@ fn compare_signal_channels<W: Write>(
     if !source2_ended {
         for batch2 in &rx2 {
             for change2 in &batch2.changes {
-                if !hier2.signal_map.contains_key(&change2.handle) {
+                if !context.hier2.signal_map.contains_key(&change2.handle) {
                     continue;
                 }
                 if prev_time.is_none_or(|t1| batch2.time >= t1) {
@@ -607,16 +658,26 @@ fn compare_signal_channels<W: Write>(
                     continue;
                 }
                 has_differences = true;
-                for name in format_handle_names(change2.handle, &hier2.signal_map, &hier2.names) {
-                    emit_file2_only(writer, &name, batch2.time, &change2.value)?;
-                }
+                emit_file2_only(
+                    &mut diff_rows,
+                    &mut fst_diff,
+                    context.hier2,
+                    change2.handle,
+                    batch2.time,
+                    &change2.value,
+                );
             }
         }
     }
 
+    diff_rows.write(writer)?;
+
     Ok(DiffReport {
         has_differences,
         trim,
+        fst_diff_signal_count: fst_diff
+            .as_ref()
+            .map_or(0, |recorder| recorder.signal_count()),
     })
 }
 
@@ -646,37 +707,50 @@ fn compare_signal_channels_stateful<W: Write>(
     writer: &mut W,
     rx1: channel::Receiver<TimeBatch>,
     rx2: channel::Receiver<TimeBatch>,
-    handle_mapping: &HashMap<usize, Vec<usize>>,
+    handle_mapping: &HashMap<usize, Vec<HandleMatch>>,
     context: CompareSignalContext<'_>,
+    mut fst_diff: Option<&mut FstDiffRecorder>,
 ) -> std::io::Result<DiffReport> {
-    let CompareSignalContext {
-        hier1,
-        hier2,
-        real_epsilon,
-        ignore_xz,
-    } = context;
     let mut has_differences = false;
     let mut trim = None;
+    let mut diff_rows = DiffReportRows::default();
 
-    // Flatten the file1->file2 handle mapping into (handle1, handle2) pairs plus
-    // reverse indices so a change on either side finds the pairs it touches.
-    let mut pairs: Vec<(usize, usize)> = Vec::new();
+    // Flatten the file1->file2 handle mapping into matched pairs plus reverse
+    // indices so a change on either side finds the pairs it touches. Each pair
+    // keeps its own file1 name so aliased ids report every name once.
+    struct MatchedPair {
+        handle1: usize,
+        handle2: usize,
+        name_a: crate::NameId,
+        use_real_epsilon: bool,
+    }
+    let mut pairs: Vec<MatchedPair> = Vec::new();
     let mut a_to_pairs: HashMap<usize, Vec<usize>> = HashMap::new();
     let mut b_to_pairs: HashMap<usize, Vec<usize>> = HashMap::new();
-    for (&handle1, handles2) in handle_mapping {
-        for &handle2 in handles2 {
+    for (&handle1, matches) in handle_mapping {
+        for matched in matches {
             let pair = pairs.len();
-            pairs.push((handle1, handle2));
+            pairs.push(MatchedPair {
+                handle1,
+                handle2: matched.handle_b,
+                name_a: matched.name_a,
+                use_real_epsilon: handles_are_real(
+                    context.hier1,
+                    handle1,
+                    context.hier2,
+                    matched.handle_b,
+                ),
+            });
             a_to_pairs.entry(handle1).or_default().push(pair);
-            b_to_pairs.entry(handle2).or_default().push(pair);
+            b_to_pairs.entry(matched.handle_b).or_default().push(pair);
         }
     }
-    let pair_real: Vec<bool> = pairs
-        .iter()
-        .map(|&(h1, h2)| handles_are_real(hier1, h1, hier2, h2))
-        .collect();
 
-    // Last-known value per side, keyed by handle. `None` until first seen.
+    // Which side(s) held X-like bits in matches that only passed thanks to
+    // X/Z-masking. Under --ignore-xz we assume X-like bits come from a single side.
+    let mut masked_x_sides = crate::fst_diff::SidePair::<bool>::default();
+
+    // Last-known value per side, keyed by handle. Absent until first seen.
     let mut held1: HashMap<usize, OwnedSignalValue> = HashMap::new();
     let mut held2: HashMap<usize, OwnedSignalValue> = HashMap::new();
 
@@ -710,10 +784,8 @@ fn compare_signal_channels_stateful<W: Write>(
             continue;
         }
 
+        // Pairs whose held state changed at this time; recompared once each.
         let mut changed: HashSet<usize> = HashSet::new();
-        // (name, full line) rows produced at this time, sorted by name before
-        // writing so output does not depend on stream/HashMap ordering.
-        let mut rows: Vec<(String, String)> = Vec::new();
 
         if t1 == Some(t) {
             for change in drain_time(&rx1, &mut head1, t) {
@@ -730,46 +802,74 @@ fn compare_signal_channels_stateful<W: Write>(
                 if let Some(pids) = b_to_pairs.get(&change.handle) {
                     changed.extend(pids.iter().copied());
                     held2.insert(change.handle, change.value);
-                } else if hier2.signal_map.contains_key(&change.handle) {
-                    for name in format_handle_names(change.handle, &hier2.signal_map, &hier2.names)
-                    {
-                        has_differences = true;
-                        rows.push((
-                            name.clone(),
-                            format!("{} {} {} (only in file2)", t, name, change.value),
-                        ));
-                    }
+                } else if context.hier2.signal_map.contains_key(&change.handle) {
+                    has_differences = true;
+                    emit_file2_only(
+                        &mut diff_rows,
+                        &mut fst_diff,
+                        context.hier2,
+                        change.handle,
+                        t,
+                        &change.value,
+                    );
                 }
             }
             last_t2 = Some(t);
         }
 
         for pair in changed {
-            let (handle1, handle2) = pairs[pair];
-            let (Some(value1), Some(value2)) = (held1.get(&handle1), held2.get(&handle2)) else {
+            let pair = &pairs[pair];
+            let (Some(value1), Some(value2)) = (held1.get(&pair.handle1), held2.get(&pair.handle2))
+            else {
                 // Skip until both sides have produced a value.
                 continue;
             };
-            if !value1.approx_eq(value2, real_epsilon, pair_real[pair], ignore_xz) {
-                for name in format_handle_names(handle1, &hier1.signal_map, &hier1.names) {
-                    has_differences = true;
-                    rows.push((
-                        name.clone(),
-                        format!("{} {} {} != {}", t, name, value1, value2),
-                    ));
-                }
+            if !value1.approx_eq(
+                value2,
+                context.real_epsilon,
+                pair.use_real_epsilon,
+                context.ignore_xz,
+            ) {
+                has_differences = true;
+                emit_value_diff(
+                    &mut diff_rows,
+                    &mut fst_diff,
+                    context.hier1,
+                    pair.name_a,
+                    t,
+                    value1,
+                    value2,
+                );
+            } else {
+                // Matched only thanks to X/Z-masking: note which side held X-like bits
+                // so the fst emitter can copy shared values from that side.
+                masked_x_sides.side1 |= value1.has_x_like_bits();
+                masked_x_sides.side2 |= value2.has_x_like_bits();
             }
         }
+    }
 
-        rows.sort_by(|a, b| a.0.cmp(&b.0));
-        for (_name, line) in rows {
-            writeln!(writer, "{}", line)?;
-        }
+    diff_rows.write(writer)?;
+
+    // Validate the single-X-like-side invariant only after the full report is
+    // written, so the text diff is complete even when the invariant fails.
+    // Checked for every --ignore-xz run: if both sides hold X-like bits, masking is
+    // hiding real discrepancies and the user should compare Xs directly.
+    if masked_x_sides.side1 && masked_x_sides.side2 {
+        return Err(io::Error::other(
+            "wavediff --ignore-xz: both sides hold X-like bits; drop --ignore-xz to compare them",
+        ));
+    }
+    if let Some(recorder) = fst_diff.as_deref_mut() {
+        recorder.set_masked_x_sides(&masked_x_sides);
     }
 
     Ok(DiffReport {
         has_differences,
         trim,
+        fst_diff_signal_count: fst_diff
+            .as_ref()
+            .map_or(0, |recorder| recorder.signal_count()),
     })
 }
 
@@ -840,7 +940,7 @@ fn send_wave_changes(
 ///
 /// Each inner reader produces same-time `TimeBatch`es. The k-way merge picks the
 /// batch with the smallest time and forwards it directly -- no re-batching needed.
-fn send_merged_wave_changes(
+pub(crate) fn send_merged_wave_changes(
     readers: Vec<WaveReader>,
     offsets: &[usize],
     include_sets: Option<Vec<HashSet<usize>>>,
@@ -1071,6 +1171,14 @@ pub fn diff_wave_sets_with_report<W: Write>(
         send_merged_wave_changes(readers2, &offsets2, include_sets2, start, end, tx2)
     });
 
+    let mut fst_diff = output_options
+        .fst_diff
+        .as_ref()
+        .map(|_| FstDiffRecorder::new());
+    if let Some(recorder) = fst_diff.as_mut() {
+        recorder.record_matching_candidates(&hier1, &hier2);
+        recorder.record_asymmetric_candidates(&hier1, &hier2);
+    }
     let context = CompareSignalContext {
         hier1: &hier1,
         hier2: &hier2,
@@ -1078,9 +1186,23 @@ pub fn diff_wave_sets_with_report<W: Write>(
         ignore_xz: output_options.ignore_xz,
     };
     let result = if output_options.ignore_xz {
-        compare_signal_channels_stateful(writer, rx1, rx2, &handle_mapping, context)
+        compare_signal_channels_stateful(
+            writer,
+            rx1,
+            rx2,
+            &handle_mapping,
+            context,
+            fst_diff.as_mut(),
+        )
     } else {
-        compare_signal_channels(writer, rx1, rx2, &handle_mapping, context)
+        compare_signal_channels(
+            writer,
+            rx1,
+            rx2,
+            &handle_mapping,
+            context,
+            fst_diff.as_mut(),
+        )
     };
 
     let thread1_result = match thread1.join() {
@@ -1092,9 +1214,23 @@ pub fn diff_wave_sets_with_report<W: Write>(
         Err(_) => Err(io::Error::other("wavediff set2 reader thread panicked")),
     };
 
-    let report = result?;
+    let mut report = result?;
     thread1_result?;
     thread2_result?;
+
+    if let (Some(output), Some(recorder)) = (&output_options.fst_diff, fst_diff) {
+        report.fst_diff_signal_count = recorder.signal_count();
+        if report.fst_diff_signal_count > 0 {
+            let fst_end = report.trim.as_ref().map_or(options.end, |trim| {
+                Some(
+                    options
+                        .end
+                        .map_or(trim.trim_time, |end| end.min(trim.trim_time)),
+                )
+            });
+            recorder.write_fst(output, options.start, fst_end)?;
+        }
+    }
 
     Ok(report)
 }

--- a/src/diff_report.rs
+++ b/src/diff_report.rs
@@ -1,0 +1,47 @@
+//------------------------------------------------------------------------------
+// diff_report.rs
+// Sorted text report rows for waveform diffs
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+
+use std::io::{self, Write};
+
+struct DiffOutputRow {
+    time: u64,
+    name: String,
+    sequence: usize,
+    text: String,
+}
+
+#[derive(Default)]
+pub(crate) struct DiffReportRows {
+    rows: Vec<DiffOutputRow>,
+    sequence: usize,
+}
+
+impl DiffReportRows {
+    pub(crate) fn push(&mut self, time: u64, name: String, text: String) {
+        self.rows.push(DiffOutputRow {
+            time,
+            name,
+            sequence: self.sequence,
+            text,
+        });
+        self.sequence += 1;
+    }
+
+    pub(crate) fn write<W: Write>(mut self, writer: &mut W) -> io::Result<()> {
+        self.rows.sort_by(|a, b| {
+            a.time
+                .cmp(&b.time)
+                .then_with(|| a.name.cmp(&b.name))
+                .then_with(|| a.sequence.cmp(&b.sequence))
+        });
+        for row in self.rows {
+            writeln!(writer, "{}", row.text)?;
+        }
+        Ok(())
+    }
+}

--- a/src/fst_diff.rs
+++ b/src/fst_diff.rs
@@ -1,0 +1,772 @@
+//------------------------------------------------------------------------------
+// fst_diff.rs
+// FST synthesis for waveform diffs
+//
+// SPDX-FileCopyrightText: Hudson River Trading
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use crossbeam_channel as channel;
+
+use crate::diff::{send_merged_wave_changes, OwnedSignalValue};
+use crate::{vcd, NameOptions, VarEntry, VarMeta, WaveHierarchy, WaveReader};
+
+type FstDiffSample = SidePair<Option<OwnedSignalValue>>;
+type FstDiffTimeline = BTreeMap<u64, FstDiffSample>;
+type FstDiffSingleTimeline = BTreeMap<u64, OwnedSignalValue>;
+
+/// A value held independently for each of the two diff sides.
+#[derive(Default)]
+pub struct SidePair<T> {
+    pub side1: T,
+    pub side2: T,
+}
+
+impl<T> SidePair<T> {
+    fn get(&self, is_side1: bool) -> &T {
+        if is_side1 {
+            &self.side1
+        } else {
+            &self.side2
+        }
+    }
+
+    fn get_mut(&mut self, is_side1: bool) -> &mut T {
+        if is_side1 {
+            &mut self.side1
+        } else {
+            &mut self.side2
+        }
+    }
+}
+
+/// One side's inputs for an FST diff.
+#[derive(Default)]
+pub struct FstDiffSide {
+    pub label: String,
+    pub paths: Vec<PathBuf>,
+}
+
+/// Options for writing a waveform containing only differing signals.
+pub struct FstDiffOutput {
+    pub path: PathBuf,
+    pub sides: SidePair<FstDiffSide>,
+    pub name_options: NameOptions,
+}
+
+#[derive(Default)]
+pub(crate) struct FstDiffRecorder {
+    has_diffs: bool,
+    side_signals: SidePair<BTreeSet<Vec<String>>>,
+    matching_signals: BTreeSet<Vec<String>>,
+    // Which side held X-like bits in masked matches. The comparison sets this so
+    // shared signal values are copied from the clean side under --ignore-xz.
+    masked_x_sides: SidePair<bool>,
+}
+
+impl FstDiffRecorder {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn record_diff(&mut self, segments: &[&str]) {
+        if segments.is_empty() {
+            return;
+        }
+        self.has_diffs = true;
+        let segments: Vec<String> = segments.iter().map(|s| (*s).to_string()).collect();
+        self.side_signals.side1.insert(segments.clone());
+        self.side_signals.side2.insert(segments);
+    }
+
+    /// Record which side(s) held X-like bits across masked matches, so shared
+    /// signal values are copied from the X-holding side under --ignore-xz.
+    pub(crate) fn set_masked_x_sides(&mut self, sides: &SidePair<bool>) {
+        self.masked_x_sides.side1 = sides.side1;
+        self.masked_x_sides.side2 = sides.side2;
+    }
+
+    /// Which side to copy shared (matching) signal values from. Prefers the
+    /// side that held the X-masked bits; defaults to side1.
+    fn prefer_side1_for_shared(&self) -> bool {
+        self.masked_x_sides.side1 || !self.masked_x_sides.side2
+    }
+
+    pub(crate) fn record_side1_only(&mut self, segments: &[&str]) {
+        self.record_side_only(segments, true);
+    }
+
+    pub(crate) fn record_side2_only(&mut self, segments: &[&str]) {
+        self.record_side_only(segments, false);
+    }
+
+    fn record_side_only(&mut self, segments: &[&str], is_side1: bool) {
+        if segments.is_empty() {
+            return;
+        }
+        self.has_diffs = true;
+        self.side_signals
+            .get_mut(is_side1)
+            .insert(segments.iter().map(|s| (*s).to_string()).collect());
+    }
+
+    pub(crate) fn record_matching_candidates(
+        &mut self,
+        hier1: &WaveHierarchy,
+        hier2: &WaveHierarchy,
+    ) {
+        for info in hier1.signal_map.values() {
+            for var in &info.vars {
+                let segments = hier1.names.segments(var.name);
+                if segments.is_empty() {
+                    continue;
+                }
+                let owned: Vec<String> = segments
+                    .iter()
+                    .map(|segment| (*segment).to_string())
+                    .collect();
+                if handle_var_for_segments(hier2, &owned).is_some() {
+                    self.matching_signals.insert(owned);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn record_asymmetric_candidates(
+        &mut self,
+        hier1: &WaveHierarchy,
+        hier2: &WaveHierarchy,
+    ) {
+        for info in hier1.signal_map.values() {
+            for var in &info.vars {
+                let segments = hier1.names.segments(var.name);
+                if !segments.is_empty() && hier2.names.find(&segments).is_none() {
+                    self.record_side1_only(&segments);
+                }
+            }
+        }
+        for info in hier2.signal_map.values() {
+            for var in &info.vars {
+                let segments = hier2.names.segments(var.name);
+                if !segments.is_empty() && hier1.names.find(&segments).is_none() {
+                    self.record_side2_only(&segments);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn signal_count(&self) -> usize {
+        if !self.has_diffs {
+            0
+        } else {
+            self.side_signals.side1.len()
+                + self.side_signals.side2.len()
+                + self.matching_signal_count()
+        }
+    }
+
+    fn matching_signal_count(&self) -> usize {
+        self.matching_signals
+            .iter()
+            .filter(|segments| {
+                !self.side_signals.side1.contains(*segments)
+                    && !self.side_signals.side2.contains(*segments)
+            })
+            .count()
+    }
+
+    pub(crate) fn write_fst(
+        &self,
+        output: &FstDiffOutput,
+        start: u64,
+        end: Option<u64>,
+    ) -> io::Result<()> {
+        let paths1: Vec<&Path> = output
+            .sides
+            .side1
+            .paths
+            .iter()
+            .map(PathBuf::as_path)
+            .collect();
+        let paths2: Vec<&Path> = output
+            .sides
+            .side2
+            .paths
+            .iter()
+            .map(PathBuf::as_path)
+            .collect();
+        let (readers1, hier1, offsets1) =
+            crate::open_wave_files(&paths1, &output.name_options, None)
+                .map_err(io::Error::other)?;
+        let (readers2, hier2, offsets2) =
+            crate::open_wave_files(&paths2, &output.name_options, None)
+                .map_err(io::Error::other)?;
+
+        let mut synth = FstDiffSynthesizer::new(output, self, &hier1, &hier2);
+        synth.collect_side(readers1, offsets1, true, start, end)?;
+        synth.collect_side(readers2, offsets2, false, start, end)?;
+        synth.write_fst(&output.path)
+    }
+}
+
+#[derive(Default)]
+struct FstDiffSignal {
+    single_meta: Option<VarMeta>,
+    single_timeline: FstDiffSingleTimeline,
+    side_meta: SidePair<Option<VarMeta>>,
+    timeline: FstDiffTimeline,
+}
+
+type FstDiffSignals = BTreeMap<Vec<String>, FstDiffSignal>;
+
+#[derive(Clone, Copy)]
+enum Track {
+    Single,
+    Side1,
+    Side2,
+}
+
+/// Per-side state accumulated while collecting changes for one input.
+#[derive(Default)]
+struct SideCollector {
+    label: String,
+    handles: HashSet<usize>,
+    updates: HashMap<usize, Vec<(Vec<String>, Track)>>,
+}
+
+struct FstDiffSynthesizer {
+    signals: FstDiffSignals,
+    sides: SidePair<SideCollector>,
+}
+
+impl FstDiffSynthesizer {
+    fn new(
+        output: &FstDiffOutput,
+        recorder: &FstDiffRecorder,
+        hier1: &WaveHierarchy,
+        hier2: &WaveHierarchy,
+    ) -> Self {
+        let mut synth = Self {
+            signals: BTreeMap::new(),
+            sides: SidePair {
+                side1: SideCollector {
+                    label: sanitize_vcd_identifier(&output.sides.side1.label),
+                    ..Default::default()
+                },
+                side2: SideCollector {
+                    label: sanitize_vcd_identifier(&output.sides.side2.label),
+                    ..Default::default()
+                },
+            },
+        };
+
+        for segments in &recorder.side_signals.side1 {
+            synth.add_side_signal(hier1, segments, true);
+        }
+        for segments in &recorder.side_signals.side2 {
+            synth.add_side_signal(hier2, segments, false);
+        }
+        if recorder.has_diffs {
+            // Copy shared (matching) signals from the side that held the
+            // X-like masked bits, so --ignore-xz shared values keep the Xs.
+            let prefer_side1 = recorder.prefer_side1_for_shared();
+            let hier = if prefer_side1 { hier1 } else { hier2 };
+            for segments in recorder.matching_signals.iter().filter(|segments| {
+                !recorder.side_signals.side1.contains(*segments)
+                    && !recorder.side_signals.side2.contains(*segments)
+            }) {
+                synth.add_single_signal(hier, segments, prefer_side1);
+            }
+        }
+
+        synth
+    }
+
+    fn add_side_signal(&mut self, hier: &WaveHierarchy, segments: &[String], is_side1: bool) {
+        let Some((handle, var)) = handle_var_for_segments(hier, segments) else {
+            return;
+        };
+        let signal = self.signals.entry(segments.to_vec()).or_default();
+        *signal.side_meta.get_mut(is_side1) = Some(var.meta.clone());
+        let track = if is_side1 { Track::Side1 } else { Track::Side2 };
+        let side = self.sides.get_mut(is_side1);
+        side.handles.insert(handle);
+        side.updates
+            .entry(handle)
+            .or_default()
+            .push((segments.to_vec(), track));
+    }
+
+    fn add_single_signal(&mut self, hier: &WaveHierarchy, segments: &[String], is_side1: bool) {
+        let Some((handle, var)) = handle_var_for_segments(hier, segments) else {
+            return;
+        };
+        let signal = self.signals.entry(segments.to_vec()).or_default();
+        signal.single_meta = Some(var.meta.clone());
+        let side = self.sides.get_mut(is_side1);
+        side.handles.insert(handle);
+        side.updates
+            .entry(handle)
+            .or_default()
+            .push((segments.to_vec(), Track::Single));
+    }
+
+    fn collect_side(
+        &mut self,
+        readers: Vec<WaveReader>,
+        offsets: Vec<usize>,
+        is_side1: bool,
+        start: u64,
+        end: Option<u64>,
+    ) -> io::Result<()> {
+        let side = self.sides.get(is_side1);
+        if side.handles.is_empty() {
+            return Ok(());
+        }
+        let include_sets = include_sets_for_handles(&side.handles, &offsets);
+        let updates = &side.updates;
+
+        let (tx, rx) = channel::bounded(64);
+        let thread = std::thread::spawn(move || {
+            send_merged_wave_changes(readers, &offsets, Some(include_sets), start, end, tx)
+        });
+
+        for batch in &rx {
+            for change in batch.changes {
+                let Some(handle_updates) = updates.get(&change.handle) else {
+                    continue;
+                };
+                for (segments, track) in handle_updates {
+                    let signal = self.signals.entry(segments.clone()).or_default();
+                    match track {
+                        Track::Single => {
+                            signal
+                                .single_timeline
+                                .insert(batch.time, change.value.clone());
+                        }
+                        Track::Side1 => {
+                            signal.timeline.entry(batch.time).or_default().side1 =
+                                Some(change.value.clone());
+                        }
+                        Track::Side2 => {
+                            signal.timeline.entry(batch.time).or_default().side2 =
+                                Some(change.value.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        match thread.join() {
+            Ok(result) => result,
+            Err(_) => Err(io::Error::other("wavediff fst-diff reader thread panicked")),
+        }
+    }
+
+    fn write_fst(&self, path: &Path) -> io::Result<()> {
+        let tmp_vcd = std::env::temp_dir().join(format!(
+            "wavediff-{}-{}.vcd",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+
+        self.write_vcd(&tmp_vcd)?;
+        let converter = std::env::var_os("VCD2FST").unwrap_or_else(|| "vcd2fst".into());
+        let status = std::process::Command::new(converter)
+            .arg(&tmp_vcd)
+            .arg(path)
+            .status()
+            .map_err(|e| io::Error::other(format!("failed to run vcd2fst: {}", e)))?;
+        let _ = std::fs::remove_file(&tmp_vcd);
+        if !status.success() {
+            return Err(io::Error::other(format!("vcd2fst exited with {}", status)));
+        }
+        Ok(())
+    }
+
+    fn write_vcd(&self, path: &Path) -> io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut writer = vcd::Writer::new(BufWriter::new(file));
+        writer.version("wavediff")?;
+        writer.timescale(1, vcd::TimescaleUnit::NS)?;
+
+        let mut ids = BTreeMap::new();
+        let mut current_scope: Vec<String> = Vec::new();
+        for (segments, signal) in &self.signals {
+            let Some((leaf, scope)) = segments.split_last() else {
+                continue;
+            };
+            let common = common_prefix_len(&current_scope, scope);
+            while current_scope.len() > common {
+                writer.upscope()?;
+                current_scope.pop();
+            }
+            for segment in &scope[common..] {
+                writer.add_module(&sanitize_vcd_identifier(segment))?;
+                current_scope.push(segment.clone());
+            }
+
+            let single_id = if let Some(meta) = &signal.single_meta {
+                let (reference, index) = vcd_reference_for_leaf(leaf);
+                Some(writer.add_var(
+                    vcd_var_type_from_meta(meta),
+                    meta.size.max(1),
+                    &reference,
+                    index,
+                )?)
+            } else {
+                None
+            };
+            let mut side_ids: SidePair<Option<vcd::IdCode>> = SidePair::default();
+            for is_side1 in [true, false] {
+                if let Some(meta) = signal.side_meta.get(is_side1) {
+                    let label = &self.sides.get(is_side1).label;
+                    let (reference, index) = vcd_side_reference_for_leaf(leaf, label);
+                    *side_ids.get_mut(is_side1) = Some(writer.add_var(
+                        vcd_var_type_from_meta(meta),
+                        meta.size.max(1),
+                        &reference,
+                        index,
+                    )?);
+                }
+            }
+            ids.insert(segments.clone(), (single_id, side_ids));
+        }
+        while !current_scope.is_empty() {
+            writer.upscope()?;
+            current_scope.pop();
+        }
+        writer.enddefinitions()?;
+
+        let mut times = BTreeSet::new();
+        for signal in self.signals.values() {
+            times.extend(signal.single_timeline.keys().copied());
+            times.extend(signal.timeline.keys().copied());
+        }
+
+        let mut last_written: HashMap<vcd::IdCode, OwnedSignalValue> = HashMap::new();
+        for time in times {
+            writer.timestamp(time)?;
+            for (segments, signal) in &self.signals {
+                let (single_id, side_ids) = &ids[segments];
+                if let (Some(id), Some(meta), Some(value)) = (
+                    single_id,
+                    signal.single_meta.as_ref(),
+                    signal.single_timeline.get(&time),
+                ) {
+                    write_raw_change_if_changed(&mut writer, &mut last_written, *id, meta, value)?;
+                }
+                if let Some(sample) = signal.timeline.get(&time) {
+                    for is_side1 in [true, false] {
+                        if let (Some(id), Some(meta), Some(value)) = (
+                            side_ids.get(is_side1),
+                            signal.side_meta.get(is_side1).as_ref(),
+                            sample.get(is_side1).as_ref(),
+                        ) {
+                            write_raw_change_if_changed(
+                                &mut writer,
+                                &mut last_written,
+                                *id,
+                                meta,
+                                value,
+                            )?;
+                        }
+                    }
+                }
+            }
+        }
+
+        writer.flush()
+    }
+}
+
+fn include_sets_for_handles(handles: &HashSet<usize>, offsets: &[usize]) -> Vec<HashSet<usize>> {
+    let mut include_sets: Vec<HashSet<usize>> =
+        (0..offsets.len()).map(|_| HashSet::new()).collect();
+    for &handle in handles {
+        let reader_idx = match offsets.binary_search(&handle) {
+            Ok(idx) => idx,
+            Err(0) => continue,
+            Err(idx) => idx - 1,
+        };
+        include_sets[reader_idx].insert(handle - offsets[reader_idx]);
+    }
+    include_sets
+}
+
+fn handle_var_for_segments<'a>(
+    hier: &'a WaveHierarchy,
+    segments: &[String],
+) -> Option<(usize, &'a VarEntry)> {
+    let refs: Vec<&str> = segments.iter().map(String::as_str).collect();
+    let name = hier.names.find(&refs)?;
+    hier.signal_map.iter().find_map(|(&handle, info)| {
+        info.vars
+            .iter()
+            .find(|var| var.name == name)
+            .map(|var| (handle, var))
+    })
+}
+
+fn common_prefix_len(left: &[String], right: &[String]) -> usize {
+    left.iter()
+        .zip(right)
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn vcd_var_type_from_meta(meta: &VarMeta) -> vcd::VarType {
+    vcd::VarType::from_str_ext(meta.var_type, true).unwrap_or(vcd::VarType::Wire)
+}
+
+fn vcd_reference_for_leaf(leaf: &str) -> (String, Option<vcd::ReferenceIndex>) {
+    let (base, index) = split_numeric_range_suffix(leaf);
+    (sanitize_vcd_identifier(base), index)
+}
+
+fn vcd_side_reference_for_leaf(
+    leaf: &str,
+    side_label: &str,
+) -> (String, Option<vcd::ReferenceIndex>) {
+    let (base, index) = split_numeric_range_suffix(leaf);
+    (
+        format!("{}__{}", sanitize_vcd_identifier(base), side_label),
+        index,
+    )
+}
+
+fn split_numeric_range_suffix(s: &str) -> (&str, Option<vcd::ReferenceIndex>) {
+    if !s.ends_with(']') {
+        return (s, None);
+    }
+    let Some(pos) = s
+        .rfind(" [")
+        .or_else(|| s.rfind('[').filter(|&pos| pos > 0))
+    else {
+        return (s, None);
+    };
+    let bracket_start = s[pos..].find('[').unwrap() + pos + 1;
+    let content = &s[bracket_start..s.len() - 1];
+    if content.is_empty() || !content.chars().all(|c| c.is_ascii_digit() || c == ':') {
+        return (s, None);
+    }
+    let index = if let Some((hi, lo)) = content.split_once(':') {
+        let Ok(hi) = hi.parse() else {
+            return (s, None);
+        };
+        let Ok(lo) = lo.parse() else {
+            return (s, None);
+        };
+        vcd::ReferenceIndex::Range(hi, lo)
+    } else {
+        let Ok(bit) = content.parse() else {
+            return (s, None);
+        };
+        vcd::ReferenceIndex::BitSelect(bit)
+    };
+    (&s[..pos], Some(index))
+}
+
+fn write_raw_change_if_changed<W: Write>(
+    writer: &mut vcd::Writer<W>,
+    last_written: &mut HashMap<vcd::IdCode, OwnedSignalValue>,
+    id: vcd::IdCode,
+    meta: &VarMeta,
+    value: &OwnedSignalValue,
+) -> io::Result<()> {
+    if last_written.get(&id).is_some_and(|last| last == value) {
+        return Ok(());
+    }
+    write_raw_change(writer, id, meta, value)?;
+    last_written.insert(id, value.clone());
+    Ok(())
+}
+
+fn write_raw_change<W: Write>(
+    writer: &mut vcd::Writer<W>,
+    id: vcd::IdCode,
+    meta: &VarMeta,
+    value: &OwnedSignalValue,
+) -> io::Result<()> {
+    if is_real_var_type(meta.var_type) {
+        let real = match value {
+            OwnedSignalValue::Real(real) => *real,
+            OwnedSignalValue::String(bytes) => std::str::from_utf8(bytes)
+                .ok()
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(f64::NAN),
+        };
+        return writer.change_real(id, real);
+    }
+
+    let OwnedSignalValue::String(bytes) = value else {
+        return writer.change_real(
+            id,
+            match value {
+                OwnedSignalValue::Real(real) => *real,
+                OwnedSignalValue::String(_) => unreachable!(),
+            },
+        );
+    };
+    if meta.var_type == "string" {
+        let text = std::str::from_utf8(bytes).unwrap_or("x");
+        return writer.change_string(id, text);
+    }
+    if let Some(values) = digital_value_bits(bytes, meta.size) {
+        if meta.size <= 1 {
+            return writer.change_scalar(id, values[0]);
+        }
+        return writer.change_vector(id, values);
+    }
+
+    let text = std::str::from_utf8(bytes).unwrap_or("x");
+    writer.change_string(id, text)
+}
+
+fn digital_value_bits(bytes: &[u8], width: u32) -> Option<Vec<vcd::Value>> {
+    let width = width.max(1) as usize;
+    if !bytes.is_empty() && bytes.len() <= width {
+        if let Some(mut values) = bytes
+            .iter()
+            .map(|byte| digital_char_value(*byte))
+            .collect::<Option<Vec<_>>>()
+        {
+            if values.len() < width {
+                let extension = match values[0] {
+                    vcd::Value::X => vcd::Value::X,
+                    vcd::Value::Z => vcd::Value::Z,
+                    _ => vcd::Value::V0,
+                };
+                let mut padded = vec![extension; width - values.len()];
+                padded.append(&mut values);
+                return Some(padded);
+            }
+            return Some(values);
+        }
+    }
+
+    let packed_len = width.div_ceil(8);
+    if bytes.len() == packed_len {
+        let mut values = Vec::with_capacity(width);
+        for bit_index in 0..width {
+            let byte = bytes[bit_index / 8];
+            let bit = (byte >> (7 - (bit_index & 7))) & 1;
+            values.push(if bit == 0 {
+                vcd::Value::V0
+            } else {
+                vcd::Value::V1
+            });
+        }
+        return Some(values);
+    }
+
+    None
+}
+
+fn digital_char_value(byte: u8) -> Option<vcd::Value> {
+    match byte {
+        b'0' => Some(vcd::Value::V0),
+        b'1' => Some(vcd::Value::V1),
+        b'x' | b'X' | b'u' | b'U' | b'w' | b'W' | b'-' | b'?' => Some(vcd::Value::X),
+        b'z' | b'Z' => Some(vcd::Value::Z),
+        b'h' | b'H' => Some(vcd::Value::V1),
+        b'l' | b'L' => Some(vcd::Value::V0),
+        _ => None,
+    }
+}
+
+fn sanitize_vcd_identifier(s: &str) -> String {
+    let mut out = String::with_capacity(s.len().max(1));
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' || c == '$' {
+            out.push(c);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    if out
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_digit() || c == '$')
+    {
+        out.insert(0, '_');
+    }
+    out
+}
+
+fn is_real_var_type(var_type: &str) -> bool {
+    matches!(
+        var_type,
+        "real" | "realtime" | "shortreal" | "real_parameter"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digital_value_bits_accepts_packed_bytes() {
+        let values = digital_value_bits(&[0b1010_0000], 4).unwrap();
+
+        assert_eq!(
+            values,
+            vec![
+                vcd::Value::V1,
+                vcd::Value::V0,
+                vcd::Value::V1,
+                vcd::Value::V0
+            ]
+        );
+    }
+
+    #[test]
+    fn digital_value_bits_accepts_logic_chars() {
+        let values = digital_value_bits(b"10xzHLUW-?", 10).unwrap();
+
+        assert_eq!(
+            values,
+            vec![
+                vcd::Value::V1,
+                vcd::Value::V0,
+                vcd::Value::X,
+                vcd::Value::Z,
+                vcd::Value::V1,
+                vcd::Value::V0,
+                vcd::Value::X,
+                vcd::Value::X,
+                vcd::Value::X,
+                vcd::Value::X,
+            ]
+        );
+    }
+
+    #[test]
+    fn digital_value_bits_pads_short_vectors() {
+        let values = digital_value_bits(b"1010", 8).unwrap();
+
+        assert_eq!(
+            values,
+            vec![
+                vcd::Value::V0,
+                vcd::Value::V0,
+                vcd::Value::V0,
+                vcd::Value::V0,
+                vcd::Value::V1,
+                vcd::Value::V0,
+                vcd::Value::V1,
+                vcd::Value::V0,
+            ]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 
 mod cat;
 mod diff;
+mod diff_report;
+mod fst_diff;
 #[allow(dead_code, unused_imports, clippy::manual_repeat_n)]
 mod vcd;
 
@@ -17,6 +19,7 @@ pub use diff::{
     diff_waves, open_and_read_wave_sets, open_and_read_waves, DiffOptions, DiffOutputOptions,
     DiffReport, DiffSide, TrimReport, WaveSets,
 };
+pub use fst_diff::{FstDiffOutput, FstDiffSide, SidePair};
 
 use fst_reader::{
     is_fst_file, FstArrayType, FstEnumType, FstHierarchyEntry, FstPackType, FstReader,

--- a/tests/data/diff/alias_split_a.vcd
+++ b/tests/data/diff/alias_split_a.vcd
@@ -1,0 +1,14 @@
+$timescale 1ps $end
+$scope module m $end
+$scope module s0 $end
+$var wire 1 ! a $end
+$upscope $end
+$scope module s1 $end
+$var wire 1 ! c $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpvars
+0!
+$end

--- a/tests/data/error/alias_split_b_value_diff.vcd
+++ b/tests/data/error/alias_split_b_value_diff.vcd
@@ -1,0 +1,15 @@
+$timescale 1ps $end
+$scope module m $end
+$scope module s0 $end
+$var wire 1 0 a $end
+$upscope $end
+$scope module s1 $end
+$var wire 1 1 c $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpvars
+00
+11
+$end

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -190,6 +190,67 @@ fn test_buffered_file2_only_diffs_are_sorted() {
 }
 
 #[test]
+fn test_report_timestamps_are_monotonic_across_buffered_file2_only_rows() {
+    let pid = std::process::id();
+    let file1 = std::env::temp_dir().join(format!("wavetools-monotonic-{}-1.vcd", pid));
+    let file2 = std::env::temp_dir().join(format!("wavetools-monotonic-{}-2.vcd", pid));
+    std::fs::write(
+        &file1,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! a $end
+$var wire 1 \" b $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#20
+1!
+",
+    )
+    .expect("write file1");
+    std::fs::write(
+        &file2,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! a $end
+$var wire 1 \" b $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1\"
+#30
+1!
+",
+    )
+    .expect("write file2");
+
+    let (has_diff, output) = run_wave_diff_test(
+        file1.to_str().expect("temp path should be UTF-8"),
+        file2.to_str().expect("temp path should be UTF-8"),
+    );
+    assert!(
+        has_diff,
+        "expected buffered file2-only row and missing time"
+    );
+
+    let expected = "\
+10 t.b 1 (only in file2)
+20 t.a 1 (missing time in file2)
+";
+    assert_eq!(output, expected, "diff output should be time-sorted");
+
+    let _ = std::fs::remove_file(file1);
+    let _ = std::fs::remove_file(file2);
+}
+
+#[test]
 fn test_terminal_same_tick_file1_only_changes_are_trimmed() {
     let pid = std::process::id();
     let file1 = std::env::temp_dir().join(format!("wavetools-terminal-trim-{}-1.vcd", pid));
@@ -587,6 +648,22 @@ fn test_diff_vcd_aliased_idcodes_reports_each_name_once() {
     assert_eq!(
         output, expected,
         "Expected one diff per aliased signal name"
+    );
+}
+
+#[test]
+fn test_diff_aliased_to_split_idcodes_reports_matched_name_once() {
+    let (has_diff, output) = run_wave_diff_test(
+        "tests/data/diff/alias_split_a.vcd",
+        "tests/data/error/alias_split_b_value_diff.vcd",
+    );
+    assert!(has_diff, "Changed split alias should differ");
+    let expected = "\
+0 m.s1.c 0 != 1
+";
+    assert_eq!(
+        output, expected,
+        "Expected only the split signal name to be reported"
     );
 }
 
@@ -1897,4 +1974,534 @@ fn test_cli_wavediff_reports_ignored_longer_input() {
         "stderr should report ignored trailing samples: {}",
         stderr
     );
+}
+
+#[test]
+fn test_cli_fst_diff_writes_side_by_side_signals() {
+    let out_path =
+        std::env::temp_dir().join(format!("wavetools-fst-diff-{}.fst", std::process::id()));
+    let _ = std::fs::remove_file(&out_path);
+    let out_str = out_path.to_str().expect("temp path should be UTF-8");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_wavediff"))
+        .args([
+            "--fst-diff",
+            out_str,
+            "tests/data/counter.fst",
+            "tests/data/counter.value.diff.fst",
+        ])
+        .output()
+        .expect("Failed to run wavediff");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Expected value diff. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        out_path.exists(),
+        "Expected fst diff output at {}",
+        out_path.display()
+    );
+
+    let names = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .args(["--names", "--sort", out_str])
+        .output()
+        .expect("Failed to run wavecat");
+    assert!(
+        names.status.success(),
+        "wavecat should read fst diff. stderr: {}",
+        String::from_utf8_lossy(&names.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&names.stdout);
+    let name_lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        name_lines.contains(&"t.clk"),
+        "missing unsuffixed matching clock signal: {}",
+        stdout
+    );
+    assert!(
+        name_lines.contains(&"t.cyc"),
+        "missing unsuffixed matching signal: {}",
+        stdout
+    );
+    assert!(
+        !name_lines.contains(&"t.the_sub.cyc_plus_one"),
+        "differing signal should not also get an unsuffixed trace: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("t.the_sub.cyc_plus_one__counter"),
+        "missing file1 side signal: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("t.the_sub.cyc_plus_one__counter_value_diff"),
+        "missing file2 side signal: {}",
+        stdout
+    );
+
+    let attrs = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .args(["--attrs", out_str])
+        .output()
+        .expect("Failed to run wavecat --attrs");
+    assert!(
+        attrs.status.success(),
+        "wavecat should read fst diff attrs. stderr: {}",
+        String::from_utf8_lossy(&attrs.stderr)
+    );
+    let attrs_stdout = String::from_utf8_lossy(&attrs.stdout);
+    assert!(
+        attrs_stdout
+            .lines()
+            .any(|line| line == "t.cyc  integer  32"),
+        "matching signal should keep raw integer metadata: {}",
+        attrs_stdout
+    );
+    assert!(
+        !attrs_stdout
+            .lines()
+            .any(|line| line == "t.the_sub.cyc_plus_one  integer  32"),
+        "differing signal should not have unsuffixed metadata: {}",
+        attrs_stdout
+    );
+    assert!(
+        attrs_stdout.contains("t.the_sub.cyc_plus_one__counter  integer  32"),
+        "file1 side signal should keep raw integer metadata: {}",
+        attrs_stdout
+    );
+    assert!(
+        attrs_stdout.contains("t.the_sub.cyc_plus_one__counter_value_diff  integer  32"),
+        "file2 side signal should keep raw integer metadata: {}",
+        attrs_stdout
+    );
+
+    let values = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .arg(out_str)
+        .output()
+        .expect("Failed to run wavecat values");
+    assert!(
+        values.status.success(),
+        "wavecat should read fst diff values. stderr: {}",
+        String::from_utf8_lossy(&values.stderr)
+    );
+    let values_stdout = String::from_utf8_lossy(&values.stdout);
+    assert!(
+        values_stdout.contains("0 t.cyc 00000000000000000000000000000000"),
+        "matching signal should include raw unsuffixed values: {}",
+        values_stdout
+    );
+    assert!(
+        !values_stdout
+            .lines()
+            .any(|line| line.starts_with("0 t.the_sub.cyc_plus_one ")),
+        "differing signal should not include unsuffixed values: {}",
+        values_stdout
+    );
+    assert!(
+        values_stdout
+            .contains("0 t.the_sub.cyc_plus_one__counter 00000000000000000000000000000001"),
+        "file1 side signal should include initial raw values: {}",
+        values_stdout
+    );
+    assert!(
+        values_stdout.contains(
+            "0 t.the_sub.cyc_plus_one__counter_value_diff 00000000000000000000000000000001"
+        ),
+        "file2 side signal should include initial raw values: {}",
+        values_stdout
+    );
+    assert!(
+        values_stdout
+            .contains("10 t.the_sub.cyc_plus_one__counter 00000000000000000000000000000010"),
+        "file1 side signal should include divergent raw values: {}",
+        values_stdout
+    );
+    assert!(
+        values_stdout.contains(
+            "10 t.the_sub.cyc_plus_one__counter_value_diff 00000000000000000000000000000100"
+        ),
+        "file2 side signal should include divergent raw values: {}",
+        values_stdout
+    );
+
+    let _ = std::fs::remove_file(&out_path);
+}
+
+#[test]
+fn test_cli_fst_diff_does_not_bake_ranges_into_signal_names() {
+    let pid = std::process::id();
+    let file1 = std::env::temp_dir().join(format!("wavetools-fst-range-base-{}.vcd", pid));
+    let file2 = std::env::temp_dir().join(format!("wavetools-fst-range-diff-{}.vcd", pid));
+    let out_path = std::env::temp_dir().join(format!("wavetools-fst-range-{}.fst", pid));
+    let _ = std::fs::remove_file(&out_path);
+
+    std::fs::write(
+        &file1,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 2 ! data [1:0] $end
+$upscope $end
+$enddefinitions $end
+#0
+b00 !
+#10
+b01 !
+",
+    )
+    .expect("write file1");
+    std::fs::write(
+        &file2,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 2 ! data [1:0] $end
+$upscope $end
+$enddefinitions $end
+#0
+b00 !
+#10
+b10 !
+",
+    )
+    .expect("write file2");
+
+    let out_str = out_path.to_str().expect("temp path should be UTF-8");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_wavediff"))
+        .args([
+            "--fst-diff",
+            out_str,
+            file1.to_str().expect("temp path should be UTF-8"),
+            file2.to_str().expect("temp path should be UTF-8"),
+        ])
+        .output()
+        .expect("Failed to run wavediff");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Expected value diff. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let names = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .args(["--names", "--sort", out_str])
+        .output()
+        .expect("Failed to run wavecat");
+    assert!(
+        names.status.success(),
+        "wavecat should read fst diff. stderr: {}",
+        String::from_utf8_lossy(&names.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&names.stdout);
+    assert!(
+        stdout.contains("t.data__"),
+        "range signal should keep its base name: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("_1_0"),
+        "range suffix should not be baked into generated FST identifiers: {}",
+        stdout
+    );
+
+    let _ = std::fs::remove_file(file1);
+    let _ = std::fs::remove_file(file2);
+    let _ = std::fs::remove_file(out_path);
+}
+
+#[test]
+fn test_cli_fst_diff_includes_side_only_signals() {
+    let pid = std::process::id();
+    let file1 = std::env::temp_dir().join(format!("wavetools-fst-side-only-a-{}.vcd", pid));
+    let file2 = std::env::temp_dir().join(format!("wavetools-fst-side-only-b-{}.vcd", pid));
+    let out_path = std::env::temp_dir().join(format!("wavetools-fst-side-only-{}.fst", pid));
+    let _ = std::fs::remove_file(&out_path);
+
+    std::fs::write(
+        &file1,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 2 \" only_a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+b01 \"
+#10
+1!
+b10 \"
+",
+    )
+    .expect("write file1");
+    std::fs::write(
+        &file2,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 2 \" only_b $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+b11 \"
+#10
+1!
+b00 \"
+",
+    )
+    .expect("write file2");
+
+    let out_str = out_path.to_str().expect("temp path should be UTF-8");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_wavediff"))
+        .args([
+            "--fst-diff",
+            out_str,
+            file1.to_str().expect("temp path should be UTF-8"),
+            file2.to_str().expect("temp path should be UTF-8"),
+        ])
+        .output()
+        .expect("Failed to run wavediff");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Expected name diff. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let names = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .args(["--names", "--sort", out_str])
+        .output()
+        .expect("Failed to run wavecat names");
+    assert!(
+        names.status.success(),
+        "wavecat should read fst diff. stderr: {}",
+        String::from_utf8_lossy(&names.stderr)
+    );
+    let names_stdout = String::from_utf8_lossy(&names.stdout);
+    assert!(
+        names_stdout
+            .lines()
+            .any(|line| line.starts_with("t.only_a__")),
+        "missing file1-only suffixed trace: {}",
+        names_stdout
+    );
+    assert!(
+        names_stdout
+            .lines()
+            .any(|line| line.starts_with("t.only_b__")),
+        "missing file2-only suffixed trace: {}",
+        names_stdout
+    );
+    assert!(
+        !names_stdout.lines().any(|line| line == "t.only_a"),
+        "file1-only signal should not be unsuffixed: {}",
+        names_stdout
+    );
+    assert!(
+        !names_stdout.lines().any(|line| line == "t.only_b"),
+        "file2-only signal should not be unsuffixed: {}",
+        names_stdout
+    );
+
+    let values = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .arg(out_str)
+        .output()
+        .expect("Failed to run wavecat values");
+    assert!(
+        values.status.success(),
+        "wavecat should read fst diff values. stderr: {}",
+        String::from_utf8_lossy(&values.stderr)
+    );
+    let values_stdout = String::from_utf8_lossy(&values.stdout);
+    assert!(
+        values_stdout
+            .lines()
+            .any(|line| line.starts_with("0 t.only_a__") && line.ends_with("01")),
+        "missing file1-only raw value: {}",
+        values_stdout
+    );
+    assert!(
+        values_stdout
+            .lines()
+            .any(|line| line.starts_with("0 t.only_b__") && line.ends_with("11")),
+        "missing file2-only raw value: {}",
+        values_stdout
+    );
+
+    let _ = std::fs::remove_file(file1);
+    let _ = std::fs::remove_file(file2);
+    let _ = std::fs::remove_file(out_path);
+}
+
+#[test]
+fn test_cli_fst_diff_omits_missing_side_changes() {
+    let out_path = std::env::temp_dir().join(format!(
+        "wavetools-fst-diff-edge-{}.fst",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&out_path);
+    let out_str = out_path.to_str().expect("temp path should be UTF-8");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_wavediff"))
+        .args([
+            "--fst-diff",
+            out_str,
+            "tests/data/counter.fst",
+            "tests/data/counter.edge_time.diff.fst",
+        ])
+        .output()
+        .expect("Failed to run wavediff");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Expected edge-time diff. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let values = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .arg(out_str)
+        .output()
+        .expect("Failed to run wavecat");
+    assert!(
+        values.status.success(),
+        "wavecat should read fst diff. stderr: {}",
+        String::from_utf8_lossy(&values.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&values.stdout);
+    assert!(
+        !stdout.lines().any(|line| line.starts_with("0 t.clk ")),
+        "differing clock should not be represented as an unsuffixed matching trace: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("20 t.clk__counter 0"),
+        "missing file1 raw clock edge: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("21 t.clk__counter_edge_time_diff 0"),
+        "missing file2 raw clock edge: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("MISSING"),
+        "fst diff should not emit synthetic MISSING values: {}",
+        stdout
+    );
+
+    let _ = std::fs::remove_file(&out_path);
+}
+
+#[test]
+fn test_cli_fst_diff_truncates_to_shorter_input() {
+    let pid = std::process::id();
+    let file1 = std::env::temp_dir().join(format!("wavetools-fst-trim-{}-1.vcd", pid));
+    let file2 = std::env::temp_dir().join(format!("wavetools-fst-trim-{}-2.vcd", pid));
+    let out_path = std::env::temp_dir().join(format!("wavetools-fst-trim-{}.fst", pid));
+    let _ = std::fs::remove_file(&out_path);
+
+    std::fs::write(
+        &file1,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 1 \" a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1!
+1\"
+#20
+0!
+0\"
+#30
+1!
+1\"
+#40
+0!
+0\"
+",
+    )
+    .expect("write file1");
+    std::fs::write(
+        &file2,
+        "\
+$timescale 1ns $end
+$scope module t $end
+$var wire 1 ! clk $end
+$var wire 1 \" a $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+0\"
+#10
+1!
+0\"
+#20
+0!
+0\"
+",
+    )
+    .expect("write file2");
+
+    let out_str = out_path.to_str().expect("temp path should be UTF-8");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_wavediff"))
+        .args([
+            "--fst-diff",
+            out_str,
+            file1.to_str().expect("temp path should be UTF-8"),
+            file2.to_str().expect("temp path should be UTF-8"),
+        ])
+        .output()
+        .expect("Failed to run wavediff");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Expected value diff. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let values = std::process::Command::new(env!("CARGO_BIN_EXE_wavecat"))
+        .arg(out_str)
+        .output()
+        .expect("Failed to run wavecat");
+    assert!(
+        values.status.success(),
+        "wavecat should read fst diff. stderr: {}",
+        String::from_utf8_lossy(&values.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&values.stdout);
+    assert!(
+        stdout.contains("20 t.clk 0"),
+        "fst diff should include samples through the shorter input: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("30 "),
+        "fst diff should not include raw samples after the shorter input: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("40 "),
+        "fst diff should not include raw samples after the shorter input: {}",
+        stdout
+    );
+
+    let _ = std::fs::remove_file(file1);
+    let _ = std::fs::remove_file(file2);
+    let _ = std::fs::remove_file(out_path);
 }


### PR DESCRIPTION
Stacked PRs:
 * __->__#29
 * #28
 * #27
 * #26


--- --- ---

### Add wavediff --fst-diff output


Emits a merged fst representing the combined signals.

Writes the name as <signal>_<filename> if the signal is only present in one, or is different.

Also writes signals that are in common. If `--ignore-xs` is specified, the
common signal is copied from the side with Xs;

wavediff errors if both sides hold Xs while using `--ignore-xs` now, regardless of recording fsts.
