### PR TITLE
Reject non-finite wavediff epsilon

### DIFF
--- a/src/bin/wavediff.rs
+++ b/src/bin/wavediff.rs
@@ -144,8 +144,11 @@ fn run(args: Args) -> Result<bool, String> {
         }
     }
     if let Some(eps) = args.epsilon {
-        if eps < 0.0 {
-            return Err(format!("--epsilon must be non-negative, got {}", eps));
+        if !eps.is_finite() || eps < 0.0 {
+            return Err(format!(
+                "--epsilon must be finite and non-negative, got {}",
+                eps
+            ));
         }
     }
 

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -836,6 +836,20 @@ mod common;
 use common::{run_wavecat_cli, run_wavediff_cli};
 
 #[test]
+fn test_cli_wavediff_rejects_non_finite_epsilon() {
+    for epsilon in ["NaN", "inf"] {
+        let output = run_wavediff_cli(&[
+            "--epsilon",
+            epsilon,
+            "tests/data/counter.fst",
+            "tests/data/counter.fst",
+        ]);
+        assert_eq!(output.status.code(), Some(2));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("must be finite and non-negative"));
+    }
+}
+
+#[test]
 fn test_cli_attr_diff_nonzero_exit() {
     // Different attrs, same values -- should exit 1
     let output = run_wavediff_cli(&["tests/data/enum_attrs.a.vcd", "tests/data/enum_attrs.b.vcd"]);


### PR DESCRIPTION
## Problem

`wavediff` accepts `NaN` and infinite values for `--epsilon`. An infinite tolerance can make different real-valued waveforms compare equal, while `NaN` gives unordered comparison behavior.

## Fix

Reject non-finite epsilon values alongside negative values before starting the comparison.

## Test

- Added a CLI regression covering `NaN` and `inf`
- `cargo test --quiet`
- `cargo clippy --quiet -- -D warnings`
- `rustfmt --edition 2021 --config skip_children=true --check src/bin/wavediff.rs tests/diff_test.rs`
- `git diff --check`

## Risk

Low. This only narrows invalid CLI input; zero and positive finite tolerances keep their existing behavior.
